### PR TITLE
feat: add support for Rubberduck folder navigation

### DIFF
--- a/src/Document/DocumentShortcuts.cls
+++ b/src/Document/DocumentShortcuts.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = True
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Document")
 Option Explicit
 
 '-------------------------------------------------------------------------------

--- a/src/Document/Enums.bas
+++ b/src/Document/Enums.bas
@@ -1,10 +1,11 @@
 Attribute VB_Name = "Enums"
+'@Folder("markDoc.src.Document")
 Option Explicit
 
 Public Enum BlockType
 '   Containers
     List
-    ListItem
+    listItem
     Quote
 
 '   Leaves

--- a/src/Document/InlineContent.cls
+++ b/src/Document/InlineContent.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Document")
 Option Explicit
 
 '-------------------------------------------------------------------------------

--- a/src/Interface/IBlock.cls
+++ b/src/Interface/IBlock.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Interface")
 Option Explicit
 
 '-------------------------------------------------------------------------------

--- a/src/Interface/IBlockContainer.cls
+++ b/src/Interface/IBlockContainer.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Interface")
 Option Explicit
 
 '-------------------------------------------------------------------------------

--- a/src/Interface/IBlockContent.cls
+++ b/src/Interface/IBlockContent.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Interface")
 Option Explicit
 
 '-------------------------------------------------------------------------------

--- a/src/Interface/IBlockLeaf.cls
+++ b/src/Interface/IBlockLeaf.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Interface")
 Option Explicit
 
 '-------------------------------------------------------------------------------

--- a/src/Interface/IBlockList.cls
+++ b/src/Interface/IBlockList.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Interface")
 Option Explicit
 
 '-------------------------------------------------------------------------------

--- a/src/Interface/IBlockListItem.cls
+++ b/src/Interface/IBlockListItem.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Interface")
 Option Explicit
 
 '-------------------------------------------------------------------------------

--- a/src/Interface/IFileReader.cls
+++ b/src/Interface/IFileReader.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Interface")
 Option Explicit
 
 '-------------------------------------------------------------------------------

--- a/src/Interface/ISection.cls
+++ b/src/Interface/ISection.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Interface")
 Option Explicit
 
 '-------------------------------------------------------------------------------

--- a/src/LexerWriter/BlockContainers/BlockContainer.cls
+++ b/src/LexerWriter/BlockContainers/BlockContainer.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.LexerWriter.BlockContainers")
 Option Explicit
 Implements IBlock
 Implements IBlockContent

--- a/src/LexerWriter/BlockContainers/BlockContainerList.cls
+++ b/src/LexerWriter/BlockContainers/BlockContainerList.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.LexerWriter.BlockContainers")
 Option Explicit
 Implements IBlock
 Implements IBlockList

--- a/src/LexerWriter/BlockContainers/BlockContainerListItem.cls
+++ b/src/LexerWriter/BlockContainers/BlockContainerListItem.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.LexerWriter.BlockContainers")
 Option Explicit
 Implements IBlock
 Implements IBlockListItem

--- a/src/LexerWriter/BlockContainers/BlockContainerQuote.cls
+++ b/src/LexerWriter/BlockContainers/BlockContainerQuote.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.LexerWriter.BlockContainers")
 Option Explicit
 Implements IBlock
 Implements IBlockContainer

--- a/src/LexerWriter/BlockLeaves/BlockLeafBlankLine.cls
+++ b/src/LexerWriter/BlockLeaves/BlockLeafBlankLine.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.LexerWriter.BlockLeaves")
 Option Explicit
 Implements IBlock
 Implements IBlockLeaf

--- a/src/LexerWriter/BlockLeaves/BlockLeafFencedCode.cls
+++ b/src/LexerWriter/BlockLeaves/BlockLeafFencedCode.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.LexerWriter.BlockLeaves")
 Option Explicit
 Implements IBlock
 Implements IBlockLeaf

--- a/src/LexerWriter/BlockLeaves/BlockLeafHeading.cls
+++ b/src/LexerWriter/BlockLeaves/BlockLeafHeading.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.LexerWriter.BlockLeaves")
 Option Explicit
 Implements IBlock
 Implements IBlockLeaf
@@ -101,7 +102,7 @@ End Sub
 Public Sub StyleContent(styleDoc As Document)
 '   This method MUST be called after WriteContent.
     Dim styleName As String
-    styleName = Enums.BlockTypeToStyleName(BlockType.Heading, HeadingLevel) 
+    styleName = Enums.BlockTypeToStyleName(BlockType.Heading, HeadingLevel)
 
     Dim inlineCont As InlineContent
     Set inlineCont = mInlineConts(1)

--- a/src/LexerWriter/BlockLeaves/BlockLeafIndentedCode.cls
+++ b/src/LexerWriter/BlockLeaves/BlockLeafIndentedCode.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.LexerWriter.BlockLeaves")
 Option Explicit
 Implements IBlock
 Implements IBlockLeaf

--- a/src/LexerWriter/BlockLeaves/BlockLeafParagraph.cls
+++ b/src/LexerWriter/BlockLeaves/BlockLeafParagraph.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.LexerWriter.BlockLeaves")
 Option Explicit
 Implements IBlock
 Implements IBlockLeaf

--- a/src/LexerWriter/LexerMarkdown.cls
+++ b/src/LexerWriter/LexerMarkdown.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.LexerWriter")
 Option Explicit
 
 '-------------------------------------------------------------------------------
@@ -266,7 +267,7 @@ Private Sub ParseLineType(line As String)
 '       line: The raw line as it is read from the source.
 
     Dim cleanLine As String
-    Dim unindentLine As String
+    Dim UnindentLine As String
     Dim thisIndentLevel As Long
 
 '   Clean, get indentation, and unindent line.
@@ -275,11 +276,11 @@ Private Sub ParseLineType(line As String)
     If Trim(cleanLine) = vbNullString Then
         thisIndentLevel = ThisBlock.IndentationLevel
     Else
-        unindentLine = Utils.unindentLine(cleanLine, ThisBlock.IndentationLevel)
-        thisIndentLevel = Utils.GetIndentationLevel(unindentLine)
+        UnindentLine = Utils.UnindentLine(cleanLine, ThisBlock.IndentationLevel)
+        thisIndentLevel = Utils.GetIndentationLevel(UnindentLine)
     End If
 
-    ParseLineTypeAction cleanLine, unindentLine, thisIndentLevel
+    ParseLineTypeAction cleanLine, UnindentLine, thisIndentLevel
 End Sub
 
 Private Sub ParseLineTypeAction( _

--- a/src/LexerWriter/Parser.cls
+++ b/src/LexerWriter/Parser.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = True
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.LexerWriter")
 Option Explicit
 
 '-------------------------------------------------------------------------------
@@ -42,7 +43,7 @@ Public Function IsCodeBlockFence( _
     Dim fenceChar  As String
 
     If Not fence = vbNullString Then
-'       Check fence matches left side of line    
+'       Check fence matches left side of line
         If Left(line, Len(fence)) = fence Then
 '           Check entire line only fence characters.
             fenceChar = Left(fence, 1)

--- a/src/Utilities/FileReaderHttp.cls
+++ b/src/Utilities/FileReaderHttp.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Utilities")
 Option Explicit
 Implements IFileReader
 
@@ -32,7 +33,7 @@ End Property
 ' Methods
 '-------------------------------------------------------------------------------
 Public Function PeekNextLine() As String
-Attribute Enumerator.VB_Description = "Returns the next line to be read without advancing the pointer."
+Attribute PeekNextLine.VB_Description = "Returns the next line to be read without advancing the pointer."
     If IsEoF Then Throw = Errs.FileReaderEOF
     PeekNextLine = mLines.Peek
 End Function
@@ -61,7 +62,7 @@ Public Sub OpenStream(args As String)
     Dim useProxy As Boolean
 
 '   Set up the GET request parameters.
-    spltArgs = split(args, ",")
+    spltArgs = Split(args, ",")
     If UBound(spltArgs) = 3 Then
         useProxy = True
         proxyUrl = spltArgs(1)
@@ -83,7 +84,7 @@ Public Sub OpenStream(args As String)
             .SetProxyCredentials proxyUsr, proxyPwd
         End If
         .Send
-'       Convert the result from an ANSI byte array to unicode.        
+'       Convert the result from an ANSI byte array to unicode.
         httpResult = StrConv(.ResponseBody, vbUnicode)
     End With
 

--- a/src/Utilities/FileReaderIo.cls
+++ b/src/Utilities/FileReaderIo.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Utilities")
 Option Explicit
 Implements IFileReader
 

--- a/src/Utilities/List.cls
+++ b/src/Utilities/List.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Utilities")
 Option Explicit
 
 '-------------------------------------------------------------------------------
@@ -51,7 +52,7 @@ Public Property Get Count() As Long
 End Property
 
 Public Property Get Items() As Collection
-    Attribute Items.VB_UserMemId = 0
+Attribute Items.VB_UserMemId = 0
     Set Items = mBase
 End Property
 
@@ -59,7 +60,7 @@ Public Property Get Enumerator() As IUnknown
 Attribute Enumerator.VB_Description = "Gets an enumerator that iterates through the List."
 Attribute Enumerator.VB_UserMemId = -4
 'Gets an enumerator that iterates through the List.
-    Set Enumerator = mBase.[_NewEnum]    
+    Set Enumerator = mBase.[_NewEnum]
 End Property
 
 

--- a/src/Utilities/Logger.cls
+++ b/src/Utilities/Logger.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = True
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Utilities")
 Option Explicit
 
 '-------------------------------------------------------------------------------

--- a/src/Utilities/Throw.cls
+++ b/src/Utilities/Throw.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = True
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Utilities")
 Option Explicit
 
 '-------------------------------------------------------------------------------
@@ -33,7 +34,7 @@ Public Enum Errs
     FileReaderWarnEmptyFile
 
 '   Lexer
-    LexerWarnNothingToWrite    
+    LexerWarnNothingToWrite
 
 '   Parser
     ParserIndentLevelOutsideRange
@@ -53,7 +54,7 @@ Private mThrowLevel As Level
 ' Properties
 '-------------------------------------------------------------------------------
 Public Property Let Exception(errType As Errs)
-    Attribute Exception.VB_UserMemId = 0
+Attribute Exception.VB_UserMemId = 0
     Dim errDesc As String
     Dim logLevel As Level
 
@@ -70,7 +71,7 @@ End Property
 
 Public Property Let ThrowLevel(var As Level)
     Dim loglev As String
-    logLev = Mid(Logger.LevelLookup(var), 1, 4)
+    loglev = Mid(Logger.LevelLookup(var), 1, 4)
     Logger.Log "ThrowLevel set to " & loglev, NoLevel
     mThrowLevel = var
 End Property

--- a/src/Utilities/Utils.cls
+++ b/src/Utilities/Utils.cls
@@ -7,6 +7,7 @@ Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = True
 Attribute VB_Exposed = False
+'@Folder("markDoc.src.Utilities")
 Option Explicit
 
 '-------------------------------------------------------------------------------
@@ -42,17 +43,17 @@ Public Function UnindentLine(line As String, indentLevel As Long) As String
     End If
 
 '   Throw if there's no line or the indent level is less than 0.
-    If line = vbNullString or indentLevel < 0 Then
+    If line = vbNullString Or indentLevel < 0 Then
         Throw = Errs.UtilsBadArguments
         UnindentLine = line
         Exit Function
     End If
 
-    dim i As Long
-    dim c As String
+    Dim i As Long
+    Dim c As String
     
     For i = 1 To indentLevel
-'       Throw if we hit the end of the line.    
+'       Throw if we hit the end of the line.
         If i > Len(line) Then
             Throw = Errs.UtilsBadArguments
             UnindentLine = line
@@ -61,14 +62,14 @@ Public Function UnindentLine(line As String, indentLevel As Long) As String
 
         c = Mid(line, i, 1)
         Select Case c
-'           Iterate only when we hit a space.        
+'           Iterate only when we hit a space.
             Case Is = " ":
 
-'           Replace tabs with four spaces.            
+'           Replace tabs with four spaces.
             Case Is = Chr(ASCII_TAB):
                 line = InsertReplace(line, "    ", i, 1)
 
-'           Throw for any other character.                
+'           Throw for any other character.
             Case Else:
                 Throw = Errs.UtilsStringIndentNotBlank
                 UnindentLine = line
@@ -262,7 +263,7 @@ Public Function Between(n As Long, a As Long, b As Long) As Boolean
 '   Returns:
 '       True if n between or equal to a or b.
 '
-    Between = n >= a And n <= b   
+    Between = n >= a And n <= b
 End Function
 
 Public Function Min(a As Long, b As Long) As Long

--- a/tests/test_area51.bas
+++ b/tests/test_area51.bas
@@ -1,4 +1,5 @@
 Attribute VB_Name = "test_area51"
+'@Folder("markDoc.Tests")
 Option Explicit
 
 Public Function ParseHeadingLevel(headingText As String) As Long

--- a/tests/test_md.bas
+++ b/tests/test_md.bas
@@ -1,4 +1,5 @@
 Attribute VB_Name = "test_md"
+'@Folder("markDoc.Tests")
 Option Explicit
 
 Const GITHUB As String = "https://raw.githubusercontent.com/SSlinky/markdoc/master/tests/"
@@ -8,13 +9,13 @@ Sub test_RunMarkDoc()
     DocumentShortcuts.Attach ThisDocument
 
     Dim lexer As LexerMarkdown
-    Dim stream As IIo
+    Dim stream As IFileReader
     
     Logger.LoggingLevel = Information
     Throw.ThrowLevel = NoLevel
 
     Set lexer = New LexerMarkdown
-    Set stream = New IoFileReader
+    Set stream = New FileReaderIo
 
     stream.OpenStream ActiveDocument.Path & "\tests\test_md.md"
     lexer.ParseMarkdown stream
@@ -32,7 +33,7 @@ Sub test_RunMarkDoc_FromHttp()
     Throw.ThrowLevel = NoLevel
 
     Set lexer = New LexerMarkdown
-    Set stream = New HttpFileReader
+    Set stream = New FileReaderIo
 
     stream.OpenStream GITHUB & "test_md.md"
     lexer.ParseMarkdown stream
@@ -44,8 +45,8 @@ Sub test_EmptyDoc()
     Dim stream1 As IFileReader
     Dim stream2 As IFileReader
 
-    Set stream1 = New IoFileReader
-    Set stream2 = New IoFileReader
+    Set stream1 = New FileReaderIo
+    Set stream2 = New FileReaderIo
 
     stream1.OpenStream ActiveDocument.Path & "\tests\test_empty.md"
     stream2.OpenStream ActiveDocument.Path & "\tests\test_md.md"

--- a/tests/test_proxy.bas
+++ b/tests/test_proxy.bas
@@ -1,4 +1,5 @@
 Attribute VB_Name = "test_proxy"
+'@Folder("markDoc.Tests")
 Option Explicit
 
 Const GITHUB As String = "https://raw.githubusercontent.com/SSlinky/markdoc/master/tests/"
@@ -40,7 +41,8 @@ Sub test_RunMarkDoc_from_http_behind_proxy()
 
     Set lexer = New LexerMarkdown
     Set stream = New FileReaderHttp
-    secrets = private_test_proxy.PROXYCREDS
+    
+    ' secrets = private_test_proxy.PROXYCREDS
 
     stream.OpenStream GITHUB & "test_md.md" & secrets
     lexer.ParseMarkdown stream


### PR DESCRIPTION
Closes #2

Rubberduck folder annotations added to code modules.

Three files renamed to align filenames with name attributes

IIo.cls > IFileReader.cls
FileReader.cls > FileReaderIo.cls
test_FileReaderHttp.bas > test_proxy.bas